### PR TITLE
Add additional values: 'deploymentAnnotations', 'args', 'command'

### DIFF
--- a/charts/incident-bot/Chart.yaml
+++ b/charts/incident-bot/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.9
+version: 1.4.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/incident-bot/templates/deployment.yaml
+++ b/charts/incident-bot/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "incident-bot.fullname" . }}
   labels:
     {{- include "incident-bot.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -38,6 +42,14 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:v{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.args }}
+          args:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          {{- with .Values.command }}
+          command:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.port | default 3000 }}

--- a/charts/incident-bot/values.yaml
+++ b/charts/incident-bot/values.yaml
@@ -4,12 +4,16 @@
 
 affinity: {}
 
+args: []
+
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+
+command: []
 
 configMap:
   create: true
@@ -56,6 +60,8 @@ configMap:
 database:
   enabled: false
   password:
+
+deploymentAnnotations: {}
 
 envFromSecret:
   enabled: false


### PR DESCRIPTION
Added additional values for the deployment.

You can now add `annotations` like the chart allows under `pods`

And the `args` and `command` for things like sourcing an environmental file from a vault container prior to running the application. 